### PR TITLE
Remove bashisms

### DIFF
--- a/createproject.sh
+++ b/createproject.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/sh
 
 #Generate a new project from your HTML5 Boilerplate repo clone
 #by: Rick Waldron & Michael Cetrulo
@@ -31,11 +31,12 @@ src=$(git rev-parse --show-toplevel) || {
   echo "try running the script from within html5-boilerplate directories." >&2
   exit 1
 }
-[[ -d $src ]] || {
+
+if [ ! -d $src ]; then
   echo "fatal: could not determine html5-boilerplate's root directory." >&2
   echo "try updating git." >&2
   exit 1
-}
+fi
 
 if [ $# -eq 1 ]
 then
@@ -44,20 +45,20 @@ then
 fi
 
 # get a name for new project from input
-while [[ -z $name ]]
+while [ -z $name ]
 do
     echo "To create a new html5-boilerplate project, enter a new directory name:"
     read name || exit
 done
 
-if [[ "$name" = /* ]]
+if [ "$name" = /* ]
 then
     dst=$name
 else
     dst=$src/../$name
 fi
 
-if [[ -d $dst ]]
+if [ -d $dst ]
 then
     echo "$dst exists"
 else


### PR DESCRIPTION
# what are bashisms?

As wiktionary.org describes it:

>  A shell command specific to Bash.
> They are basically specific shell commands and shortcuts the bash shell has implemented that others don't.
# Why are they bad?

They are incompatibillities to other shell environments that sooner or later will break the code for a user. 
To prevent this the POSIX standard was introduced clearly stating which features and syntax a shell has to have to comply with it. Have a look the [POSIX FAQ](http://www.opengroup.org/austin/papers/posix_faq.html) if you are interested in what that actually means.
# How do I fix this?

Nowadays there are quite some resources that will help you fix/update your code such as `checkbashisms` which is a commandline tool to test a script for bashisms. Also quite a good resource for a concise look at bashisms and how to 
replace them is [Greg Wooledge's wiki page on them](http://mywiki.wooledge.org/Bashism).
