### PR TITLE
Relocateable buildscript

### DIFF
--- a/createproject.sh
+++ b/createproject.sh
@@ -48,6 +48,19 @@ print_help() {
 	echo "this behaviour expects that you are in the git repository of h5bp under /build"
 	echo ""
 	echo "If --dst is not set it will try to create the directory in the current directory"
+	echo "You can also set the same options in the ~/.h5bprc file"
+	echo "Here are the possible options:"
+	echo "\tsrc\t\t-\tThe source directory from where h5bp is located"
+	echo "\tdst\t\t-\tThe destination in which the new project shoul be created"
+	echo "\twhich_vcs\t-\tThe vcs you want to use"
+	echo "\tcommit_init\t-\tset this to \"yes\" if you want to commit the contents of the new project"
+	echo "Here is an example for the syntax(It is basically how shell variables are set):"
+	echo ""
+	echo "src=\"~/src/html5boilerplate\""
+	echo "dst=\"~/src\""
+	echo "which_vcs=\"git\""
+	echo "commit_init=\"yes\""
+	echo ""
 }
 
 # this will be overridden if --src is set on the commandline
@@ -57,6 +70,11 @@ project_name=""
 with_vcs="no"
 which_vcs=""
 commit_init="no"
+
+if [ -e $HOME/.h5bprc ]; then
+	. $HOME/.h5bprc
+fi
+
 while test "$1" != "" 
 do
 	case $1 in


### PR DESCRIPTION
With these changes you can move the createproject.sh into you PATH and run it from whereever you like and still have a project based on h5bp.
Additionally you get the chance to use a vcs for your design project from the get-go. 

Here is an example in how to run it:
~$ createproject.sh --src ~/src/web/h5bp --vcs git --dst ~/src/web/ --commit myproject
This will create a project called myproject in ~/src/web which will contain the usual h5bp sources a .git directory  
and it will do the initial commit bit for you. 

Sounds nice doesn't it?

Besides that you will have a nice on-line documentation when you run it with --help:

<pre>
$> ./createproject.sh --help
./createproject.sh (c) 2011 by Rick Waldron & Michael Cetrulo version 1.0
USAGE: ./createproject.sh [--src SRC] [--dst DST] NAME
OPTIONS:
--src -s SRC     set the source directory where your html5boilerplate lives
--dst -d DST     set the destination directory in which to create your project
--vcs VCS        make the new location a VCS repository. Currently supported
                 VCSs are: git and hg(mercurial).
--commit -c      if set will commit the copied h5bp sources into the VCS.
                 this only works with the --vcs option set

If --src is not set it will use the toplevel dir of the current git dir
this behaviour expects that you are in the git repository of h5bp under /build

If --dst is not set it will try to create the directory in the current directory
</pre>
