### PR TITLE
re-visiting issue #15

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -508,8 +508,10 @@
 
   <target name="-js.mylibs.concat" depends="-js.all.minify" description="(PRIVATE) Concatenates the JS files in dir.js.mylibs">
       <echo message="Concatenating JS libraries"/>
+      <echo message="Concatenating all files in ./${dir.intermediate}/${dir.js}/ that don't fit the H5BL folder structure" />
+      <echo message="The following will be excluded: ${file.js.bypass}, ${dir.js.libs}/*, ${dir.js.modules}/*,  ${file.root.script}, scripts-concat.js and plugins.js" />
       <concat destfile="./${dir.intermediate}/${dir.js}/otherscripts-concat.js" overwrite="no">
-        <fileset dir="./${dir.intermediate}/${dir.js}" excludes="${file.js.bypass}, ${slug.libs}/*">
+        <fileset dir="./${dir.intermediate}/${dir.js}" excludes="${file.js.bypass}, ${slug.libs}/*, ${slug.modules}/*">
           <exclude name="${file.root.script}"/>
           <exclude name="plugins.js"/>
           <exclude name="scripts-concat.js"/>

--- a/config/default.properties
+++ b/config/default.properties
@@ -23,6 +23,8 @@ dir.js.libs         = ${dir.js}/libs
 slug.libs           = libs
 # scripts in the modules directory will be minified, not concatenated, but will be cachebusted
 dir.js.modules		= ${dir.js}/modules
+# this is identical to the 'modules' in dir.js.modules but just an easier reference when you dont need the full path
+slug.modules		= modules
 dir.css             = css
 dir.images          = img
 


### PR DESCRIPTION
per additional comments on issue #15, files in js/modules/\* are no longer mixed with js/###.js in the publish folder.

also added some additional comments to explain exactly what is going on during the concatenation step
