### PR TITLE
Add jshint/jslint config to file.default.exclude.

### DIFF
--- a/config/default.properties
+++ b/config/default.properties
@@ -46,7 +46,7 @@ file.serverconfig           = .htaccess
 #
 # Files not to be copied over by the script to the publish directory
 #
-file.default.exclude        = .gitignore, .project, .settings, README.markdown, README.md, **/.git/**, **/.svn/**, ${dir.test}/**, ${dir.demo}/**, ${dir.intermediate}/**, ${dir.publish}/**, ${dir.build}/**, **/nbproject/**, *.komodoproject, **/.komodotools/**, **/dwsync.xml, **_notes, **/.hg/**, **/.idea/**
+file.default.exclude        = .gitignore, .project, .settings, .js*intrc, README.markdown, README.md, **/.git/**, **/.svn/**, ${dir.test}/**, ${dir.demo}/**, ${dir.intermediate}/**, ${dir.publish}/**, ${dir.build}/**, **/nbproject/**, *.komodoproject, **/.komodotools/**, **/dwsync.xml, **_notes, **/.hg/**, **/.idea/**
 # Declare the file.exclude property in your project.properties file if you want to exclude files / folders you have added
 # Note: you cannot declare an empty file.exclude property
 


### PR DESCRIPTION
By default don't copy jshint / jslint configuration to the publish directory
