### PR TITLE
Subdirectories

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -432,7 +432,7 @@
           </copy>
             <mkdir dir="${dir.publish}"/>
             <copy todir="${dir.publish}" includeEmptyDirs="true">
-                <dirset dir="${dir.source}/" excludes="${file.default.exclude}, ${file.exclude}" includes="*"/>
+                <dirset dir="${dir.source}/" excludes="${file.default.exclude}, ${file.exclude}" includes="**"/>
             </copy>
         </else>
     </if>


### PR DESCRIPTION
Mkdir target did not copy subdirectories to the publish folder.
A double asterisk solves this problem.
