### PR TITLE
mainpage.tmpl file missing

### DIFF
--- a/tools/jsdoc3/templates/default/tmpl/mainpage.tmpl
+++ b/tools/jsdoc3/templates/default/tmpl/mainpage.tmpl
@@ -1,0 +1,13 @@
+<?js
+var self = this;
+?>
+
+<?js if (data.kind === 'package') { ?>
+    <h3><?js= data.name ?> <?js= data.version ?></h3>
+<?js } ?>
+
+<?js if (data.readme) { ?>
+    <section>
+        <article><?js= data.readme ?></article>
+    </section>
+<?js } ?>


### PR DESCRIPTION
Per issue 110, I added the mainpage.tmpl from the jsdoc3 repo: 
https://github.com/jsdoc3/jsdoc/blob/master/templates/default/tmpl/mainpage.tmpl
