### PR TITLE
if publish/IMAGE_DIR doesn't exist BUILD FAILS

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -880,11 +880,16 @@
             </and>
             <then>
                 <!-- work around https://sourceforge.net/tracker/?func=detail&aid=2671422&group_id=151404&atid=780916 -->
-                <delete>
-                    <fileset dir="./${dir.publish}/${dir.images}/">
-                        <include name="**/*.png"/>
-                    </fileset>
-                </delete>
+                <if>
+                  <available file="./${dir.publish}/${dir.images}/" type="dir" />
+                    <then>
+                      <delete>
+                          <fileset dir="./${dir.publish}/${dir.images}/">
+                              <include name="**/*.png"/>
+                          </fileset>
+                      </delete>
+                    </then>
+                </if>
                 <apply executable="optipng" dest="./${dir.publish}/${dir.images}/" osfamily="unix">
                     <fileset dir="./${dir.source}/${dir.images}/" includes="**/*.png"  excludes="${images.bypass}, ${images.default.bypass}"/>
                     <arg value="-quiet"/>


### PR DESCRIPTION
Added if-statement to check if publish/IMAGE_DIR exists prior to deleting the dir. If dir doesn't exist build fails.
