### PR TITLE
Fix for issue #120

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,7 +6,7 @@
     <!-- the .jar file is located in the tools directory -->
     <taskdef resource="net/sf/antcontrib/antlib.xml">
         <classpath>
-            <pathelement location="${basedir}/build/tools/ant-contrib-1.0b3.jar"/>
+            <pathelement location="${basedir}/ant-build-script/tools/ant-contrib-1.0b3.jar"/>
         </classpath>
     </taskdef>
     


### PR DESCRIPTION
<pathelement location="${basedir}/build/tools/ant-contrib-1.0b3.jar"/>

to:

<pathelement location="${basedir}/ant-build-script/tools/ant-contrib-1.0b3.jar"/>

This was changed b/c the build script was failing. It was looking for ant-contrib-1.0b3.jar in the 'build' folder which does not exist.
