### PR TITLE
Optimize images within multiple directories

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -21,9 +21,6 @@
     
     <!-- merge the pages properties -->
     <var name="page-files" value="${file.pages}, ${file.pages.default.include}"/>
-
-    <!-- Merge dir.images with the additional directories -->
-    <var name="dir.images" value="${dir.images}, ${dir.images.additional}"/>
     
     <!-- Test for Ant Version Delete this task and all instances of overwrite='no' if you can't upgrade to latest-->
     <fail message="All features of the build script require Ant version 1.8.2 or greater. Please upgrade to the latest version or remove all instances of 'overwrite=no' (and this fail task) from the build script to continue">

--- a/config/default.properties
+++ b/config/default.properties
@@ -27,8 +27,9 @@ dir.js.modules		= ${dir.js}/modules
 # this is identical to the 'modules' in dir.js.modules but just an easier reference when you dont need the full path
 slug.modules		= modules
 dir.css             = css
+dir.docs            = docs
+# You can set multiple directories here, e.g: img, css/img
 dir.images          = img
-dir.docs						= docs
 
 #
 # HTML, PHP, etc files to clean and update script/css references

--- a/config/project.properties
+++ b/config/project.properties
@@ -159,12 +159,3 @@ tool.htmlcompressor.opts.extra =
 # Uncomment and include the path
 #	Example: script.require.path = js/libs/require-jquery.js
 # script.require.path =
-
-# Additional Images Directories
-# 
-# Images within these directories will be optimized.
-# 
-# You can specify additional image directories here
-# dir.images.additional = css/additional-images, js/vendor/some-library/img
-# 
-# dir.images.additional = 


### PR DESCRIPTION
Closes the following issues:
- #23
- #108

You can now pass in any additional image directories. Any .jpg or .png within those directories get's optimized.
## Example

Simply edit project.properties, set a comma seperated list of directories, if there's only a single directory everything should run fine.
#### project.properties:

dir.images = img, css/images, css/img

Every .jpg/.png within img, css/images and css/img will now get optimized.

I've tested this thoroughly on Windows, I did make some modifications and removal of duplicated code within -imagesjpg and -imagespng, it would be great if somebody could test this on a *nix system.
