### PR TITLE
relative.image.dir should be relative to dir.source

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1173,7 +1173,7 @@
                         <dirset dir="${dir.source}" includes="${dir.images}"/>
                     </path>
                     <sequential>
-                        <property name="relative.image.dir" location="@{image-dir}" relative="yes"/>
+                        <property name="relative.image.dir" location="@{image-dir}" basedir="${dir.source}" relative="yes"/>
 
                         <!-- Create the following image directory under publish if it does not exist -->
                         <if>


### PR DESCRIPTION
The relative.image.dir property was created relative to the
project base dir, which means that, when dir.source != ., the name
of the source directory was included twice.

Add the basedir parameter to determine the relative path from
dir.source.
