### PR TITLE
Revert back to yui compressor 2.4.7

### DIFF
--- a/config/default.properties
+++ b/config/default.properties
@@ -150,7 +150,7 @@ html.rev.images = false
 # Tools                                 #  
 #---------------------------------------#
 # Tools
-tool.yuicompressor          = yuicompressor-2.4.8.jar
+tool.yuicompressor          = yuicompressor-2.4.7.jar
 tool.htmlcompressor         = htmlcompressor-1.5.3.jar
 tool.csscompressor          = css-compressor/cli.php
 tool.compiler               = compiler.jar


### PR DESCRIPTION
Because version 2.4.8 of yui compressor has not yet been integrated into the project (due to a couple of bugs), we need to continue using version 2.4.7 for the time being.
