### PR TITLE
Update spacing for Ant Build Script readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ Closure Compiler, our tool for script minification, requires Java 1.6.
 
 This means that OS X versions prior to 10.6 are no longer supported out of the box.
 [SoyLatte][soylatte] provides 10.4 and 10.5 builds of OpenJDK 7 for Intel OS X machines. However, only OS X 10.5 builds of OpenJDK 7 are available for PowerPC based Macs due to a bug in the 10.4 Compiler.
-( Be sure to read the Download link as the archives are password protected "to provide a click though agreement" of the JDK licensing. )
+(Be sure to read the Download link as the archives are password protected "to provide a click though agreement" of the JDK licensing.)
 
 [soylatte]: http://landonf.bikemonkey.org/static/soylatte/
 


### PR DESCRIPTION
Fixed spacing for Ant Build Script readme. There were unnecessary spaces between the parentheses:

![screen shot 2014-09-18 at 9 37 52 pm](https://cloud.githubusercontent.com/assets/7344640/4330817/16cf458e-3fb7-11e4-92cc-b9c3f7fd2bc2.png)
