### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@ The Ant Build Script is a tool that optimizes your code for production use on th
 
 It's designed to work with HTML5 Boilerplate with minimal configuration, but it's also here to serve as a rich source of Ant tasks you can use as the basis for your own custom build scripts.
 
-##Compatibility
+## Compatibility
 While it should work with any version of HTML5 Boilerplate (with varying degrees of intervention) v1.0 of the Build Script was developed and tested against v4.0 of HTML5 Boilerplate. 
 
 ## Why use it?
@@ -34,7 +34,7 @@ Faster page load times, improved workflow and happy end users :)
 
 For most people, you can just drop the contents of the build script repo into your HTML5 Boilerplate project in a `build` folder. That's the easiest way to get up and running.
 
-###Add the build script to your project (Advanced version)
+### Add the build script to your project (Advanced version)
 Since we split out the build scripts from the main h5bp repo, you now have more options on how to integrate a build script into your project.As was mentioned you can simply drop the contents of the build script repo into a `build` folder and you're good to go. 
 
 If you'd like to merge it into your main HTML5 Boilerplate repository and preserve the build script commit history (and the ability to update from Github), alongside the H5BP commit history, please follow this workflow:

--- a/tools/readme.md
+++ b/tools/readme.md
@@ -2,42 +2,42 @@
 
 Here's a list of the amazing tools that make this script possible
 
-##HTML Validator
+## HTML Validator
 
 https://github.com/madr/HTMLvalidator
 
-##JSDoc3
+## JSDoc3
 
 https://github.com/jsdoc3/jsdoc
 
-##CSSLint
+## CSSLint
 
 https://github.com/stubbornella/csslint
 
-##Closure Compiler
+## Closure Compiler
 
 https://developers.google.com/closure/compiler/
 
-##JSHint
+## JSHint
 
 http://www.jshint.com/
 
-##JSLint
+## JSLint
 
 http://www.jslint.com/
 
-##SASS
+## SASS
 
 http://sass-lang.com/
 
-##HTMLCompressor
+## HTMLCompressor
 
 http://code.google.com/p/htmlcompressor/
 
-##LESS
+## LESS
 
 http://lesscss.org/
 
-##Rhino
+## Rhino
 
 https://developer.mozilla.org/en-US/docs/Rhino


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
